### PR TITLE
Backport Upstream creat08 open10 fix

### DIFF
--- a/testcases/kernel/syscalls/creat/creat08.c
+++ b/testcases/kernel/syscalls/creat/creat08.c
@@ -360,13 +360,12 @@ int main(int ac, char **av)
 			local_flag = FAILED;
 		}
 
-		/* Verify modes */
-		if (!(buf.st_mode & S_ISGID)) {
-			tst_resm(TFAIL,
-				 "%s: Incorrect modes, setgid bit should be set",
-				 setgid_B);
-			local_flag = FAILED;
-		}
+		/*
+		 * Skip S_ISGID check
+		 * 0fa3ecd87848 ("Fix up non-directory creation in SGID directories")
+		 * clears S_ISGID for files created by non-group members
+		 */
+
 		close(fd);
 
 		if (local_flag == PASSED) {

--- a/testcases/kernel/syscalls/mknod/mknod03.c
+++ b/testcases/kernel/syscalls/mknod/mknod03.c
@@ -142,14 +142,11 @@ int main(int ac, char **av)
 			fflag = 0;
 		}
 
-		/* Verify mode permissions of node */
-		if (!(buf.st_mode & S_ISGID)) {
-			tst_resm(TFAIL,
-				 "%s: Incorrect modes, setgid bit not "
-				 "set", node_name);
-			/* unset flag as functionality fails */
-			fflag = 0;
-		}
+		/*
+		 * Skip S_ISGID check
+		 * 0fa3ecd87848 ("Fix up non-directory creation in SGID directories")
+		 * clears S_ISGID for files created by non-group members
+		 */
 
 		/* Verify group ID */
 		if (buf.st_gid != group2_gid) {

--- a/testcases/kernel/syscalls/open/open10.c
+++ b/testcases/kernel/syscalls/open/open10.c
@@ -345,13 +345,11 @@ int main(int ac, char *av[])
 			local_flag = FAILED;
 		}
 
-		/* Verify modes */
-		if (!(buf.st_mode & S_ISGID)) {
-			tst_resm(TFAIL,
-				 "%s: Incorrect modes, setgid bit not set",
-				 setgid_B);
-			local_flag = FAILED;
-		}
+		/*
+		 * Skip S_ISGID check
+		 * 0fa3ecd87848 ("Fix up non-directory creation in SGID directories")
+		 * clears S_ISGID for files created by non-group members
+		 */
 
 		if (local_flag == PASSED) {
 			tst_resm(TPASS, "Test passed in block2.");


### PR DESCRIPTION
With the introduction of patch : https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0fa3ecd87848c9c93c2c828ef4c3a8ca36ce46c7 , which has been backported, LTP test cases for mknod03, creat08 and open10 fail.
Those two upstream commits fix this by removing those tests.